### PR TITLE
Fixed numpy version issue

### DIFF
--- a/tutorials/demo_notebooks/demo_pipeline_standalone_kfp/demo-pipeline.ipynb
+++ b/tutorials/demo_notebooks/demo_pipeline_standalone_kfp/demo-pipeline.ipynb
@@ -129,7 +129,7 @@
    "source": [
     "@component(\n",
     "    base_image=\"python:3.10\",\n",
-    "    packages_to_install=[\"pandas~=1.4.2\"],\n",
+    "    packages_to_install=[\"numpy~=1.26.4\", \"pandas~=1.4.2\"],\n",
     "    output_component_file='components/pull_data_component.yaml',\n",
     ")\n",
     "def pull_data(url: str, data: Output[Dataset]):\n",
@@ -161,7 +161,7 @@
    "source": [
     "@component(\n",
     "    base_image=\"python:3.10\",\n",
-    "    packages_to_install=[\"pandas~=1.4.2\", \"scikit-learn~=1.0.2\"],\n",
+    "    packages_to_install=[\"numpy~=1.26.4\", \"pandas~=1.4.2\", \"scikit-learn~=1.0.2\"],\n",
     "    output_component_file='components/preprocess_component.yaml',\n",
     ")\n",
     "def preprocess(\n",
@@ -217,7 +217,7 @@
     "\n",
     "@component(\n",
     "    base_image=\"python:3.10\",\n",
-    "    packages_to_install=[\"numpy\", \"pandas~=1.4.2\", \"scikit-learn~=1.0.2\", \"mlflow~=2.4.1\", \"boto3~=1.21.0\"],\n",
+    "    packages_to_install=[\"numpy~=1.26.4\", \"pandas~=1.4.2\", \"scikit-learn~=1.0.2\", \"mlflow~=2.4.1\", \"boto3~=1.21.0\"],\n",
     "    output_component_file='components/train_component.yaml',\n",
     ")\n",
     "def train(\n",


### PR DESCRIPTION
Fixed https://github.com/OSS-MLOPS-PLATFORM/oss-mlops-platform/issues/41 for this notebook by fixing numpy version to 1.26.4 compatible (which is latest 1.x version at the moment.