### PR TITLE
Numpy update to standalone kfp notebook

### DIFF
--- a/tutorials/demo_notebooks/demo_pipeline_standalone_kfp/demo-pipeline.ipynb
+++ b/tutorials/demo_notebooks/demo_pipeline_standalone_kfp/demo-pipeline.ipynb
@@ -474,7 +474,7 @@
    "source": [
     " @component(\n",
     "    base_image=\"python:3.9\",  # kserve on python 3.10 comes with a dependency that fails to get installed\n",
-    "    packages_to_install=[\"kserve==0.11.0\", \"scikit-learn~=1.0.2\"],\n",
+    "    packages_to_install=[\"numpy~=1.26.4\", \"kserve==0.11.0\", \"scikit-learn~=1.0.2\"],\n",
     "    output_component_file='components/inference_component.yaml',\n",
     ")\n",
     "def inference(\n",


### PR DESCRIPTION
Added the Numpy package to the Inference component in the demo pipeline standalone kfp notebook. The local kfp standalone installation required this in order to be able to complete the Inference step in the demo pipeline.